### PR TITLE
set cookie_params.secure=false for tests

### DIFF
--- a/config/app.build.yml
+++ b/config/app.build.yml
@@ -11,7 +11,7 @@ users:
 cookie_secret: 0665b089efe587e560fc79c4218ac6e43181e9076a582905dbb991f05c6785ab133fee05d0f28d292b908dab09a3200d1eedb6aebcdcd77ed49bbbba4aeef5ce
 cookie_params:
   same_site: 'None'
-  secure: true
+  secure: false
 
 # needed to take a screenshot
 libvirt_rw: true


### PR DESCRIPTION
A secure cookie is only sent to the server with an encrypted request over the HTTPS protocol

https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies